### PR TITLE
stdenv.xml: documentation for makeFlagsArray

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -692,7 +692,7 @@ nothing.</para>
     spaces, e.g.
 
 <programlisting>
-makeFlagsArray=(CFLAGS="-O0 -g" LDFLAGS="-lfoo -lbar")
+makeFlagsArray=("CFLAGS=-O0 -g" "LDFLAGS=-lfoo -lbar")
 </programlisting>
 
     Note that shell arrays cannot be passed through environment


### PR DESCRIPTION
It seems the quotes should encompass the whole arguments.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

